### PR TITLE
absorb mock rename

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/DebugFrameworksDynamicMenuCommandTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/DebugFrameworksDynamicMenuCommandTests.cs
@@ -61,12 +61,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
         public void ExecCommand_MultipleStartupProjects_VerifyCorrectFrameworkSet(int cmdIndex, bool expected)
         {
             var frameworks1 = new List<string>() { "net461", "netcoreapp1.0" };
-            var activeDebugFrameworkSvcs1 = new IActiveDebugFrameworkServicesFactory()
+            var activeDebugFrameworkSvcs1 = new IActiveDebugFrameworkServicesMock()
                                                .ImplementGetActiveDebuggingFrameworkPropertyAsync(null)
                                                .ImplementGetProjectFrameworksAsync(frameworks1);
 
             var frameworks2 = new List<string>() { "net461", "netcoreapp1.0" };
-            var activeDebugFrameworkSvcs2 = new IActiveDebugFrameworkServicesFactory()
+            var activeDebugFrameworkSvcs2 = new IActiveDebugFrameworkServicesMock()
                                                .ImplementGetActiveDebuggingFrameworkPropertyAsync(null)
                                                .ImplementGetProjectFrameworksAsync(frameworks2);
             if (expected)
@@ -171,10 +171,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
         [Fact]
         public void QueryStatus_MultipleStartupProjects_NullFrameworks()
         {
-            var activeDebugFrameworkSvcs1 = new IActiveDebugFrameworkServicesFactory()
+            var activeDebugFrameworkSvcs1 = new IActiveDebugFrameworkServicesMock()
                                                .ImplementGetProjectFrameworksAsync(null);
 
-            var activeDebugFrameworkSvcs2 = new IActiveDebugFrameworkServicesFactory()
+            var activeDebugFrameworkSvcs2 = new IActiveDebugFrameworkServicesMock()
                                               .ImplementGetProjectFrameworksAsync(null);
 
             var startupHelper = new Mock<IStartupProjectHelper>();
@@ -198,10 +198,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
         [InlineData(true)]
         public void QueryStatus_MultipleStartupProjects_LessThan2Frameworks(bool createList)
         {
-            var activeDebugFrameworkSvcs1 = new IActiveDebugFrameworkServicesFactory()
+            var activeDebugFrameworkSvcs1 = new IActiveDebugFrameworkServicesMock()
                                                .ImplementGetProjectFrameworksAsync(createList ? new List<string>() { "netcoreapp1.0" } : null);
 
-            var activeDebugFrameworkSvcs2 = new IActiveDebugFrameworkServicesFactory()
+            var activeDebugFrameworkSvcs2 = new IActiveDebugFrameworkServicesMock()
                                               .ImplementGetProjectFrameworksAsync(createList ? new List<string>() { "netcoreapp1.0" } : null);
 
             var startupHelper = new Mock<IStartupProjectHelper>();
@@ -223,11 +223,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
         [Fact]
         public void QueryStatus_MultipleStartupProjects_OrderDifferent()
         {
-            var activeDebugFrameworkSvcs1 = new IActiveDebugFrameworkServicesFactory()
+            var activeDebugFrameworkSvcs1 = new IActiveDebugFrameworkServicesMock()
                                                .ImplementGetActiveDebuggingFrameworkPropertyAsync("netcoreapp1.0")
                                                .ImplementGetProjectFrameworksAsync(new List<string>() { "net461", "netcoreapp1.0" });
 
-            var activeDebugFrameworkSvcs2 = new IActiveDebugFrameworkServicesFactory()
+            var activeDebugFrameworkSvcs2 = new IActiveDebugFrameworkServicesMock()
                                              .ImplementGetActiveDebuggingFrameworkPropertyAsync("netcoreapp1.0")
                                              .ImplementGetProjectFrameworksAsync(new List<string>() { "netcoreapp1.0", "net461" });
 
@@ -250,11 +250,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
         [Fact]
         public void QueryStatus_MultipleStartupProjects_DifferentFrameworks()
         {
-            var activeDebugFrameworkSvcs1 = new IActiveDebugFrameworkServicesFactory()
+            var activeDebugFrameworkSvcs1 = new IActiveDebugFrameworkServicesMock()
                                               .ImplementGetActiveDebuggingFrameworkPropertyAsync("netcoreapp1.0")
                                               .ImplementGetProjectFrameworksAsync(new List<string>() { "net461", "netcoreapp1.0" });
 
-            var activeDebugFrameworkSvcs2 = new IActiveDebugFrameworkServicesFactory()
+            var activeDebugFrameworkSvcs2 = new IActiveDebugFrameworkServicesMock()
                                              .ImplementGetActiveDebuggingFrameworkPropertyAsync("netcoreapp1.0")
                                              .ImplementGetProjectFrameworksAsync(new List<string>() { "net45", "netcoreapp1.0" });
 
@@ -277,15 +277,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
         [Fact]
         public void QueryStatus_MultipleStartupProjects_OneSingleFramework()
         {
-            var activeDebugFrameworkSvcs1 = new IActiveDebugFrameworkServicesFactory()
+            var activeDebugFrameworkSvcs1 = new IActiveDebugFrameworkServicesMock()
                                      .ImplementGetActiveDebuggingFrameworkPropertyAsync("netcoreapp1.0")
                                      .ImplementGetProjectFrameworksAsync(new List<string>() { "net461", "netcoreapp1.0" });
 
-            var activeDebugFrameworkSvcs2 = new IActiveDebugFrameworkServicesFactory()
+            var activeDebugFrameworkSvcs2 = new IActiveDebugFrameworkServicesMock()
                                              .ImplementGetActiveDebuggingFrameworkPropertyAsync("netcoreapp1.0")
                                              .ImplementGetProjectFrameworksAsync(new List<string>() { "net461", "netcoreapp1.0" });
 
-            var activeDebugFrameworkSvcs3 = new IActiveDebugFrameworkServicesFactory()
+            var activeDebugFrameworkSvcs3 = new IActiveDebugFrameworkServicesMock()
                                       .ImplementGetActiveDebuggingFrameworkPropertyAsync("netcoreapp1.0")
                                       .ImplementGetProjectFrameworksAsync(new List<string>() { "netcoreapp1.0" });
 
@@ -315,13 +315,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
         {
             var frameworks1 = new List<string>() { "netcoreapp1.0", "net461", "net462" };
 
-            var activeDebugFrameworkSvcs1 = new IActiveDebugFrameworkServicesFactory()
+            var activeDebugFrameworkSvcs1 = new IActiveDebugFrameworkServicesMock()
                                                .ImplementGetProjectFrameworksAsync(frameworks1)
                                                .ImplementGetActiveDebuggingFrameworkPropertyAsync(activeFramework);
 
             var frameworks2 = new List<string>() { "netcoreapp1.0", "net461", "net462" };
 
-            var activeDebugFrameworkSvcs2 = new IActiveDebugFrameworkServicesFactory()
+            var activeDebugFrameworkSvcs2 = new IActiveDebugFrameworkServicesMock()
                                                .ImplementGetProjectFrameworksAsync(frameworks2)
                                                .ImplementGetActiveDebuggingFrameworkPropertyAsync(activeFramework);
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/DebugFrameworksMenuTextUpdaterTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/DebugFrameworksMenuTextUpdaterTests.cs
@@ -134,11 +134,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
         [Fact]
         public void QueryStatus_MultipleStartupProjects_NullFrameworks()
         {
-            var activeDebugFrameworkSvcs1 = new IActiveDebugFrameworkServicesFactory()
+            var activeDebugFrameworkSvcs1 = new IActiveDebugFrameworkServicesMock()
                                                .ImplementGetActiveDebuggingFrameworkPropertyAsync(null)
                                                .ImplementGetProjectFrameworksAsync(null);
 
-            var activeDebugFrameworkSvcs2 = new IActiveDebugFrameworkServicesFactory()
+            var activeDebugFrameworkSvcs2 = new IActiveDebugFrameworkServicesMock()
                                              .ImplementGetActiveDebuggingFrameworkPropertyAsync(null)
                                              .ImplementGetProjectFrameworksAsync(null);
 
@@ -157,11 +157,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
         [Fact]
         public void QueryStatus_MultipleStartupProjects_FrameworksLessThan2()
         {
-            var activeDebugFrameworkSvcs1 = new IActiveDebugFrameworkServicesFactory()
+            var activeDebugFrameworkSvcs1 = new IActiveDebugFrameworkServicesMock()
                                                .ImplementGetActiveDebuggingFrameworkPropertyAsync(null)
                                                .ImplementGetProjectFrameworksAsync(new List<string>() { "net45" });
 
-            var activeDebugFrameworkSvcs2 = new IActiveDebugFrameworkServicesFactory()
+            var activeDebugFrameworkSvcs2 = new IActiveDebugFrameworkServicesMock()
                                                .ImplementGetActiveDebuggingFrameworkPropertyAsync(null)
                                                .ImplementGetProjectFrameworksAsync(new List<string>() { "net45" });
 
@@ -180,11 +180,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
         [Fact]
         public void QueryStatus_MultipleStartupProjects_FrameworksOrderDifferent()
         {
-            var activeDebugFrameworkSvcs1 = new IActiveDebugFrameworkServicesFactory()
+            var activeDebugFrameworkSvcs1 = new IActiveDebugFrameworkServicesMock()
                                                .ImplementGetActiveDebuggingFrameworkPropertyAsync("netcoreapp1.0")
                                                .ImplementGetProjectFrameworksAsync(new List<string>() { "net461", "netcoreapp1.0" });
 
-            var activeDebugFrameworkSvcs2 = new IActiveDebugFrameworkServicesFactory()
+            var activeDebugFrameworkSvcs2 = new IActiveDebugFrameworkServicesMock()
                                              .ImplementGetActiveDebuggingFrameworkPropertyAsync("netcoreapp1.0")
                                              .ImplementGetProjectFrameworksAsync(new List<string>() { "netcoreapp1.0", "net461" });
 
@@ -203,11 +203,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
         [Fact]
         public void QueryStatus_MultipleStartupProjects_DifferentFrameworks()
         {
-            var activeDebugFrameworkSvcs1 = new IActiveDebugFrameworkServicesFactory()
+            var activeDebugFrameworkSvcs1 = new IActiveDebugFrameworkServicesMock()
                                                .ImplementGetActiveDebuggingFrameworkPropertyAsync("netcoreapp1.0")
                                                .ImplementGetProjectFrameworksAsync(new List<string>() { "net461", "netcoreapp1.0" });
 
-            var activeDebugFrameworkSvcs2 = new IActiveDebugFrameworkServicesFactory()
+            var activeDebugFrameworkSvcs2 = new IActiveDebugFrameworkServicesMock()
                                              .ImplementGetActiveDebuggingFrameworkPropertyAsync("netcoreapp1.0")
                                              .ImplementGetProjectFrameworksAsync(new List<string>() { "net45", "netcoreapp1.0" });
 
@@ -226,15 +226,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
         [Fact]
         public void QueryStatus_MultipleStartupProjects_OneSingleFramework()
         {
-            var activeDebugFrameworkSvcs1 = new IActiveDebugFrameworkServicesFactory()
+            var activeDebugFrameworkSvcs1 = new IActiveDebugFrameworkServicesMock()
                                       .ImplementGetActiveDebuggingFrameworkPropertyAsync("netcoreapp1.0")
                                       .ImplementGetProjectFrameworksAsync(new List<string>() { "net461", "netcoreapp1.0" });
 
-            var activeDebugFrameworkSvcs2 = new IActiveDebugFrameworkServicesFactory()
+            var activeDebugFrameworkSvcs2 = new IActiveDebugFrameworkServicesMock()
                                              .ImplementGetActiveDebuggingFrameworkPropertyAsync("netcoreapp1.0")
                                              .ImplementGetProjectFrameworksAsync(new List<string>() { "net461", "netcoreapp1.0" });
 
-            var activeDebugFrameworkSvcs3 = new IActiveDebugFrameworkServicesFactory()
+            var activeDebugFrameworkSvcs3 = new IActiveDebugFrameworkServicesMock()
                                       .ImplementGetActiveDebuggingFrameworkPropertyAsync("netcoreapp1.0")
                                       .ImplementGetProjectFrameworksAsync(new List<string>() { "netcoreapp1.0" });
 
@@ -253,11 +253,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
         [Fact]
         public void QueryStatus_MultipleStartupProjects_FrameworkNoActive()
         {
-            var activeDebugFrameworkSvcs1 = new IActiveDebugFrameworkServicesFactory()
+            var activeDebugFrameworkSvcs1 = new IActiveDebugFrameworkServicesMock()
                                                .ImplementGetActiveDebuggingFrameworkPropertyAsync(null)
                                                .ImplementGetProjectFrameworksAsync(new List<string>() { "net461", "netcoreapp1.0" });
 
-            var activeDebugFrameworkSvcs2 = new IActiveDebugFrameworkServicesFactory()
+            var activeDebugFrameworkSvcs2 = new IActiveDebugFrameworkServicesMock()
                                                .ImplementGetActiveDebuggingFrameworkPropertyAsync(null)
                                                .ImplementGetProjectFrameworksAsync(new List<string>() { "net461", "netcoreapp1.0" });
 
@@ -276,11 +276,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
         [Fact]
         public void QueryStatus_MultipleStartupProjects_FrameworkNoMatchingActive()
         {
-            var activeDebugFrameworkSvcs1 = new IActiveDebugFrameworkServicesFactory()
+            var activeDebugFrameworkSvcs1 = new IActiveDebugFrameworkServicesMock()
                                                .ImplementGetActiveDebuggingFrameworkPropertyAsync("net45")
                                                .ImplementGetProjectFrameworksAsync(new List<string>() { "net461", "netcoreapp1.0" });
 
-            var activeDebugFrameworkSvcs2 = new IActiveDebugFrameworkServicesFactory()
+            var activeDebugFrameworkSvcs2 = new IActiveDebugFrameworkServicesMock()
                                                .ImplementGetActiveDebuggingFrameworkPropertyAsync("net45")
                                                .ImplementGetProjectFrameworksAsync(new List<string>() { "net461", "netcoreapp1.0" });
 
@@ -299,11 +299,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
         [Fact]
         public void QueryStatus_MultipleStartupProjects_FrameworkValidActive()
         {
-            var activeDebugFrameworkSvcs1 = new IActiveDebugFrameworkServicesFactory()
+            var activeDebugFrameworkSvcs1 = new IActiveDebugFrameworkServicesMock()
                                                .ImplementGetActiveDebuggingFrameworkPropertyAsync("netcoreapp1.0")
                                                .ImplementGetProjectFrameworksAsync(new List<string>() { "net461", "netcoreapp1.0" });
 
-            var activeDebugFrameworkSvcs2 = new IActiveDebugFrameworkServicesFactory()
+            var activeDebugFrameworkSvcs2 = new IActiveDebugFrameworkServicesMock()
                                              .ImplementGetActiveDebuggingFrameworkPropertyAsync("netcoreapp1.0")
                                              .ImplementGetProjectFrameworksAsync(new List<string>() { "net461", "netcoreapp1.0" });
 


### PR DESCRIPTION
`IActiveDebugFrameworkServicesFactory` was renamed to `IActiveDebugFrameworkServicesMock` in the dev16 branch